### PR TITLE
Use SPDX identifier in license field of META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,6 +1,7 @@
 {
   "perl"        : "6",
   "name"        : "App::P6Dx",
+  "license"     : "Artistic-2.0",
   "description" : "A syntax checker & completions generator.",
   "version"     : "v0.3.0",
   "authors"     : ["Jake Russo <madcap.russo@gmail.com>"],


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license